### PR TITLE
Added login prompts configuration

### DIFF
--- a/TIM-Android-lib/src/main/java/com/trifork/timandroid/appauth/AppAuthController.kt
+++ b/TIM-Android-lib/src/main/java/com/trifork/timandroid/appauth/AppAuthController.kt
@@ -179,13 +179,12 @@ class AppAuthController(
         )
             .setScopes(config.scopes)
             .setAdditionalParameters(config.additionalParameters)
-            .let {
+            .also {
                 if(authorizationRequestNonce != null) it.setNonce(authorizationRequestNonce)
                 if (!config.prompts.isNullOrEmpty()) it.setPromptValues(config.prompts)
-                it
             }
             .build()
-
+q
 
     /**
      * Attempts to retrieve a fresh accessToken

--- a/TIM-Android-lib/src/main/java/com/trifork/timandroid/appauth/AppAuthController.kt
+++ b/TIM-Android-lib/src/main/java/com/trifork/timandroid/appauth/AppAuthController.kt
@@ -177,14 +177,11 @@ class AppAuthController(
             ResponseTypeValues.CODE,
             config.redirectUri
         )
-            .setScopes(config.scopes).let {
-                if (!config.prompts.isNullOrEmpty())
-                    it.setPromptValues(config.prompts)
-                it
-            }
+            .setScopes(config.scopes)
             .setAdditionalParameters(config.additionalParameters)
             .let {
                 if(authorizationRequestNonce != null) it.setNonce(authorizationRequestNonce)
+                if (!config.prompts.isNullOrEmpty()) it.setPromptValues(config.prompts)
                 it
             }
             .build()

--- a/TIM-Android-lib/src/main/java/com/trifork/timandroid/appauth/AppAuthController.kt
+++ b/TIM-Android-lib/src/main/java/com/trifork/timandroid/appauth/AppAuthController.kt
@@ -180,8 +180,12 @@ class AppAuthController(
             .setScopes(config.scopes)
             .setAdditionalParameters(config.additionalParameters)
             .also {
-                if(authorizationRequestNonce != null) it.setNonce(authorizationRequestNonce)
-                if (!config.prompts.isNullOrEmpty()) it.setPromptValues(config.prompts)
+                if(authorizationRequestNonce != null) {
+                    it.setNonce(authorizationRequestNonce)
+                }
+                if (!config.prompts.isNullOrEmpty()) {
+                    it.setPromptValues(config.prompts)
+                }
             }
             .build()
 

--- a/TIM-Android-lib/src/main/java/com/trifork/timandroid/appauth/AppAuthController.kt
+++ b/TIM-Android-lib/src/main/java/com/trifork/timandroid/appauth/AppAuthController.kt
@@ -184,7 +184,6 @@ class AppAuthController(
                 if (!config.prompts.isNullOrEmpty()) it.setPromptValues(config.prompts)
             }
             .build()
-q
 
     /**
      * Attempts to retrieve a fresh accessToken

--- a/TIM-Android-lib/src/main/java/com/trifork/timandroid/appauth/AppAuthController.kt
+++ b/TIM-Android-lib/src/main/java/com/trifork/timandroid/appauth/AppAuthController.kt
@@ -177,7 +177,11 @@ class AppAuthController(
             ResponseTypeValues.CODE,
             config.redirectUri
         )
-            .setScopes(config.scopes)
+            .setScopes(config.scopes).let {
+                if (!config.prompts.isNullOrEmpty())
+                    it.setPromptValues(config.prompts)
+                it
+            }
             .setAdditionalParameters(config.additionalParameters)
             .let {
                 if(authorizationRequestNonce != null) it.setNonce(authorizationRequestNonce)

--- a/TIM-Android-lib/src/main/java/com/trifork/timandroid/models/TIMConfiguration.kt
+++ b/TIM-Android-lib/src/main/java/com/trifork/timandroid/models/TIMConfiguration.kt
@@ -44,12 +44,12 @@ class TIMConfiguration {
         val fullTimUrl = Uri.parse("${timBaseUrl}/auth/realms/$realm")
 
         this.oidcConfig = TIMOpenIdConnectConfiguration(
-            fullTimUrl,
-            clientId,
-            redirectUri,
-            scopes,
-            additionalParameters,
-            prompts
+            issuerUri = fullTimUrl,
+            clientId = clientId,
+            redirectUri = redirectUri,
+            scopes = scopes,
+            additionalParameters = additionalParameters,
+            prompts = prompts
         )
         //TODO(Get the realmBaseUrl from the fullTimUrl)
         this.keyServiceConfig = TIMKeyServiceConfiguration("${timBaseUrl}/auth/realms/$realm/", keyServiceVersion)

--- a/TIM-Android-lib/src/main/java/com/trifork/timandroid/models/TIMConfiguration.kt
+++ b/TIM-Android-lib/src/main/java/com/trifork/timandroid/models/TIMConfiguration.kt
@@ -40,7 +40,7 @@ class TIMConfiguration {
      * @param encryptionMethod Optional encryption method, [TIMESEncryptionMethod.AesGcm] is default and only supported
      * @param keyServiceVersion Optional key service version, defaults to [TIMKeyServiceVersion.V1]
      */
-    constructor(timBaseUrl: URL, realm: String, clientId: String, redirectUri: Uri, scopes: List<String>, additionalParameters: Map<String, String> = mapOf(), encryptionMethod: TIMESEncryptionMethod = TIMESEncryptionMethod.AesGcm, keyServiceVersion: TIMKeyServiceVersion = TIMKeyServiceVersion.V1) {
+    constructor(timBaseUrl: URL, realm: String, clientId: String, redirectUri: Uri, scopes: List<String>, additionalParameters: Map<String, String> = mapOf(), encryptionMethod: TIMESEncryptionMethod = TIMESEncryptionMethod.AesGcm, keyServiceVersion: TIMKeyServiceVersion = TIMKeyServiceVersion.V1, prompts: List<String>? = null) {
         val fullTimUrl = Uri.parse("${timBaseUrl}/auth/realms/$realm")
 
         this.oidcConfig = TIMOpenIdConnectConfiguration(
@@ -48,7 +48,8 @@ class TIMConfiguration {
             clientId,
             redirectUri,
             scopes,
-            additionalParameters
+            additionalParameters,
+            prompts
         )
         //TODO(Get the realmBaseUrl from the fullTimUrl)
         this.keyServiceConfig = TIMKeyServiceConfiguration("${timBaseUrl}/auth/realms/$realm/", keyServiceVersion)

--- a/TIM-Android-lib/src/main/java/com/trifork/timandroid/models/openid/TIMOpenIdConnectConfiguration.kt
+++ b/TIM-Android-lib/src/main/java/com/trifork/timandroid/models/openid/TIMOpenIdConnectConfiguration.kt
@@ -7,5 +7,6 @@ data class TIMOpenIdConnectConfiguration(
     val clientId: String,
     val redirectUri: Uri,
     val scopes: List<String>,
-    val additionalParameters: Map<String, String>
+    val additionalParameters: Map<String, String>,
+    val prompts: List<String>? = null,
 )


### PR DESCRIPTION
On the falcon project we encountered an issue with the customer's IdP. Their backend sets session cookies that we cannot delete and so we need to use the `prompt` parameter (parts of OIDC specification) to inform the authentication backend that the user *should* be prompted to login again.