### PR TITLE
Ktv/proguard fix

### DIFF
--- a/TIM-Android-lib/proguard-rules.pro
+++ b/TIM-Android-lib/proguard-rules.pro
@@ -4,40 +4,44 @@
 -optimizationpasses 5
 -keepattributes SourceFile,LineNumberTable
 
--keepclasseswithmembernames class com.trifork.timandroid.appauth.**{
+-keep class com.trifork.timandroid.appauth.** {
      *;
 }
 
--keepclasseswithmembernames class com.trifork.timandroid.biometric.**{
+-keep class com.trifork.timandroid.biometric.** {
      *;
 }
 
--keepclasseswithmembernames class com.trifork.timandroid.helpers.TIMLogger{
-     *;
-}
-
-
--keepclasseswithmembernames class com.trifork.timandroid.models.**{
+-keep class com.trifork.timandroid.helpers.TIMLogger {
      *;
 }
 
 
--keepclasseswithmembernames class com.trifork.timandroid.TIM {
+-keep class com.trifork.timandroid.models.** {
+     *;
+}
+
+
+-keep class com.trifork.timandroid.TIM {
     *;
 }
 
--keepclasseswithmembernames class com.trifork.timandroid.TIMAppBackgroundMonitor {
+-keep class com.trifork.timandroid.TIMAppBackgroundMonitor {
     *;
 }
 
--keepclasseswithmembernames class com.trifork.timandroid.TIMAuth {
+-keep class com.trifork.timandroid.TIMAuth {
     *;
 }
 
--keepclasseswithmembernames class com.trifork.timandroid.TIMDataStorage {
+-keep class com.trifork.timandroid.TIMDataStorage {
     *;
 }
 
--keepclasseswithmembernames class com.trifork.timandroid.helpers.** {
+-keep class com.trifork.timandroid.helpers.** {
+    *;
+}
+
+-keep class com.trifork.timandroid.**$DefaultImpls{
     *;
 }

--- a/TIM-Android-lib/proguard-rules.pro
+++ b/TIM-Android-lib/proguard-rules.pro
@@ -42,6 +42,7 @@
     *;
 }
 
--keep class com.trifork.timandroid.**$DefaultImpls{
+#kotlin creates an internal DefaultImpls class for default implementaions of interfaces (even if there are none).
+-keep class com.trifork.timandroid.**$DefaultImpls {
     *;
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,19 +1,15 @@
-// Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
+    apply from: "./dependencies.gradle"
+
     repositories {
         google()
         mavenCentral()
         maven { url 'https://jitpack.io' }
     }
     dependencies {
-        ext.kotlin_version = '1.7.0'
         classpath "com.android.tools.build:gradle:7.2.1"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.kotlin:kotlin-serialization:$kotlin_version"
-
-
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
     }
 }
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -17,9 +17,9 @@ ext {
 
     //region Kotlin
     //https://github.com/JetBrains/kotlin
-    kotlin_version = "1.7.0"
+    kotlin_version = "1.7.10"
     //https://github.com/Kotlin/kotlinx.coroutines
-    coroutines_version = "1.6.3"
+    coroutines_version = "1.6.4"
     //https://github.com/Kotlin/kotlinx.serialization
     kotlinx_serialization_version = "1.3.3"
     kotlin = [
@@ -58,7 +58,7 @@ ext {
     //region mockk
 
     //https://search.maven.org/search?q=a:mockk
-    mockk_version = "1.12.4"
+    mockk_version = "1.12.5"
     mockk = [
             mockk : "io.mockk:mockk:$mockk_version",
             android: "io.mockk:mockk-android:$mockk_version",
@@ -74,6 +74,7 @@ ext {
     ]
     //endregion
 
+    //https://github.com/robolectric/robolectric
     roboleltric_version = "4.8.1"
     roboleltric = [
             roboleltric: "org.robolectric:robolectric:$roboleltric_version"
@@ -81,7 +82,7 @@ ext {
 
     //region Lifecycle
     //https://developer.android.com/jetpack/androidx/releases/lifecycle
-    androidx_lifecycle_version = "2.4.1"
+    androidx_lifecycle_version = "2.5.1"
     lifecycle = [
             commonJava8: "androidx.lifecycle:lifecycle-common-java8:$androidx_lifecycle_version",
             androidx: "androidx.lifecycle:lifecycle-process:$androidx_lifecycle_version"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,4 +1,3 @@
-#Mon Aug 23 15:22:49 CEST 2021
 distributionBase=GRADLE_USER_HOME
 distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
 distributionPath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Aug 23 15:22:49 CEST 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
More relaxed rules for proguard (R8) and to keep kotlin compiler's defaultImpls classes as they are referenced (even when empty ).. 