### PR TITLE
Login listener

### DIFF
--- a/TIM-Android-lib/src/main/java/com/trifork/timandroid/appauth/AppAuthController.kt
+++ b/TIM-Android-lib/src/main/java/com/trifork/timandroid/appauth/AppAuthController.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.async
 import net.openid.appauth.*
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
+import kotlin.properties.Delegates
 
 
 class AppAuthController(
@@ -27,9 +28,17 @@ class AppAuthController(
         AppAuthConfiguration.DEFAULT
     )
 
-    private var authState: AuthState? = null
+    private var loginListener: LoginListener? = null
+
+    private var authState: AuthState? by Delegates.observable(null) { _, _, newValue ->
+        loginListener?.invoke(newValue != null)
+    }
 
     override fun isLoggedIn(): Boolean = authState != null
+
+    override fun setLoginListener(listener: LoginListener?) {
+        loginListener = listener
+    }
 
     override fun getLoginIntent(scope: CoroutineScope, authorizationRequestNonce: String?): Deferred<TIMResult<Intent, TIMAuthError>> =
         scope.async {

--- a/TIM-Android-lib/src/main/java/com/trifork/timandroid/appauth/LoginListener.kt
+++ b/TIM-Android-lib/src/main/java/com/trifork/timandroid/appauth/LoginListener.kt
@@ -1,0 +1,3 @@
+package com.trifork.timandroid.appauth
+
+typealias LoginListener = (Boolean) -> Unit

--- a/TIM-Android-lib/src/main/java/com/trifork/timandroid/appauth/OpenIDConnectController.kt
+++ b/TIM-Android-lib/src/main/java/com/trifork/timandroid/appauth/OpenIDConnectController.kt
@@ -53,4 +53,9 @@ interface OpenIDConnectController {
      * Clears the current state for the logged in user
      */
     fun logout()
+
+    /**
+     * Set a listener that will be invoked with a boolean indicating whether a user is currently logged in or not.
+     */
+    fun setLoginListener(listener: LoginListener?)
 }


### PR DESCRIPTION
This listener will allow clients to react to login state changes from TIM, instead of having to manually invoke `isLoggedIn` when the auth state state might have changed. 